### PR TITLE
Update curved_drawer.dart

### DIFF
--- a/lib/curved_drawer.dart
+++ b/lib/curved_drawer.dart
@@ -68,7 +68,7 @@ class _CurvedDrawerState extends State<CurvedDrawer>
   void initState() {
     super.initState();
     _items = widget.items.map((item) {
-      DrawerNavItem(
+      return DrawerNavItem(
         icon: item.icon,
         label: item.label,
         color: widget.labelColor,


### PR DESCRIPTION
bug fix:
The getter 'icon' was called on null.
the return is missing in 
widget.items.map ((item) {
      return DrawerNavItem (
        icon: item.icon,
        label: item.label,
        color: widget.labelColor,
        background: widget.buttonBackgroundColor,
        size: widget.width / 3,
      );
    }). toList ();